### PR TITLE
Now skipping Sevii routes in routes in balance calculations

### DIFF
--- a/src/modules/routes/RegionRoute.ts
+++ b/src/modules/routes/RegionRoute.ts
@@ -11,6 +11,7 @@ export default class RegionRoute {
         public requirements: Requirement[] = [],
         public orderNumber?: number,
         public subRegion?: number,
+        public ignoreRouteInCalculations = false,
     ) {
         this.orderNumber = orderNumber || number;
     }

--- a/src/modules/routes/Routes.ts
+++ b/src/modules/routes/Routes.ts
@@ -36,10 +36,16 @@ export default class Routes {
         return this.regionRoutes[normalizedRoute - 1].number;
     }
 
-    public static normalizedNumber(region: GameConstants.Region, route: number): number {
+    public static normalizedNumber(region: GameConstants.Region, route: number, skipIgnoredRoutes: boolean): number {
         if (region === GameConstants.Region.none) {
             return route;
         }
-        return this.regionRoutes.findIndex((routeData) => routeData.region === region && routeData.number === route) + 1;
+        if (skipIgnoredRoutes && this.regionRoutes.find((routeData) => routeData.region === region && routeData.number === route).ignoreRouteInCalculations) {
+            if (route === 0) {
+                throw new Error('Not implemented for ignoreRouteInCalculations = true on first region route');
+            }
+            return this.normalizedNumber(region, route - 1, skipIgnoredRoutes);
+        }
+        return this.regionRoutes.filter((r) => !skipIgnoredRoutes || !r.ignoreRouteInCalculations).findIndex((routeData) => routeData.region === region && routeData.number === route) + 1;
     }
 }

--- a/src/scripts/GameController.ts
+++ b/src/scripts/GameController.ts
@@ -225,21 +225,21 @@ class GameController {
             if (visibleModals === 0) {
                 // Route Battles
                 if (App.game.gameState === GameConstants.GameState.fighting) {
-                    const initialRoute = MapHelper.normalizeRoute(player.route(),player.region);
+                    const initialRoute = MapHelper.normalizeRoute(player.route(),player.region, false);
                     const firstRoute = Routes.getRoutesByRegion(player.region)[0].number;
                     const lastRoute = Routes.getRoutesByRegion(player.region)[Routes.getRoutesByRegion(player.region).length - 1].number;
                     // Allow '=' to fallthrough to '+' since they share a key on many keyboards
                     switch (key) {
                         case '=':
                         case '+':
-                            if (initialRoute + 1 > MapHelper.normalizeRoute(lastRoute, player.region)) {
+                            if (initialRoute + 1 > MapHelper.normalizeRoute(lastRoute, player.region, false)) {
                                 MapHelper.moveToRoute(firstRoute, player.region);
                             } else {
                                 MapHelper.moveToRoute(Routes.unnormalizeRoute(initialRoute + 1), player.region);
                             }
                             return e.preventDefault();
                         case '-':
-                            if (initialRoute - 1 < MapHelper.normalizeRoute(firstRoute, player.region)) {
+                            if (initialRoute - 1 < MapHelper.normalizeRoute(firstRoute, player.region, false)) {
                                 MapHelper.moveToRoute(lastRoute, player.region);
                             } else {
                                 MapHelper.moveToRoute(Routes.unnormalizeRoute(initialRoute - 1), player.region);

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -276,7 +276,7 @@ TownList['Indigo Plateau Kanto'] = new Town(
 TownList['One Island'] = new Town(
     'One Island',
     GameConstants.Region.kanto,
-    [],
+    [new DockTownContent()],
     {
         requirements: [new GymBadgeRequirement(BadgeEnums.Volcano)],
     }

--- a/src/scripts/wildBattle/RouteData.ts
+++ b/src/scripts/wildBattle/RouteData.ts
@@ -301,7 +301,8 @@ Routes.add(new RegionRoute(
     }),
     [new GymBadgeRequirement(BadgeEnums.Volcano)],
     21.1,
-    KantoSubRegions.Sevii123
+    KantoSubRegions.Sevii123,
+    true
 ));
 Routes.add(new RegionRoute(
     'Kindle Road', GameConstants.Region.kanto, 27,
@@ -311,7 +312,8 @@ Routes.add(new RegionRoute(
     }),
     [new GymBadgeRequirement(BadgeEnums.Volcano)],
     21.2,
-    KantoSubRegions.Sevii123
+    KantoSubRegions.Sevii123,
+    true
 ));
 Routes.add(new RegionRoute(
     'Cape Brink', GameConstants.Region.kanto, 28,
@@ -321,7 +323,8 @@ Routes.add(new RegionRoute(
     }),
     [new GymBadgeRequirement(BadgeEnums.Volcano)],
     21.3,
-    KantoSubRegions.Sevii123
+    KantoSubRegions.Sevii123,
+    true
 ));
 Routes.add(new RegionRoute(
     'Bond Bridge', GameConstants.Region.kanto, 29,
@@ -331,7 +334,8 @@ Routes.add(new RegionRoute(
     }),
     [new GymBadgeRequirement(BadgeEnums.Volcano)],
     21.4,
-    KantoSubRegions.Sevii123
+    KantoSubRegions.Sevii123,
+    true
 ));
 
 /*

--- a/src/scripts/worldmap/MapHelper.ts
+++ b/src/scripts/worldmap/MapHelper.ts
@@ -60,8 +60,8 @@ class MapHelper {
         return !!Routes.getRoute(region, route);
     }
 
-    public static normalizeRoute(route: number, region: GameConstants.Region): number {
-        return Routes.normalizedNumber(region, route);
+    public static normalizeRoute(route: number, region: GameConstants.Region, skipIgnoredRoutes = true): number {
+        return Routes.normalizedNumber(region, route, skipIgnoredRoutes);
     }
 
     public static accessToRoute = function (route: number, region: GameConstants.Region) {


### PR DESCRIPTION
The idea is the class "RegionRoute" has a boolean, which is ignoreRouteInCalculations.
All the Sevii routes have this set, which means everything based on route index (route hp, egg steps and so on) should not change, when we add the Sevii routes.
The Sevii routes will all have hp based on the "original" route before them.
(Also added dock button to new dock town)