### PR TITLE
Fixed missing renames for Mt Chimney

### DIFF
--- a/src/scripts/dungeons/Dungeon.ts
+++ b/src/scripts/dungeons/Dungeon.ts
@@ -1687,7 +1687,7 @@ dungeonList['Meteor Falls'] = new Dungeon('Meteor Falls',
     ],
     18000, 101);
 
-dungeonList['Mt. Chimney'] = new Dungeon('Mt. Chimney',
+dungeonList['Mt. Chimney Crater'] = new Dungeon('Mt. Chimney Crater',
     [
         new DungeonTrainer('Team Magma Grunt',
             [new GymPokemon('Numel', 20000, 20)],
@@ -1708,7 +1708,7 @@ dungeonList['Mt. Chimney'] = new Dungeon('Mt. Chimney',
         {loot: 'Token_collector', weight: 3.5},
         {loot: 'Flame Plate', weight: 2},
         {loot: 'Fire_egg', weight: 1.5},
-        {loot: 'Protein', weight: 0, requirement: new ClearDungeonRequirement(400, GameConstants.getDungeonIndex('Mt. Chimney'))},
+        {loot: 'Protein', weight: 0, requirement: new ClearDungeonRequirement(400, GameConstants.getDungeonIndex('Mt. Chimney Crater'))},
     ],
     460000,
     [

--- a/src/scripts/quests/QuestLineHelper.ts
+++ b/src/scripts/quests/QuestLineHelper.ts
@@ -209,7 +209,7 @@ class QuestLineHelper {
         createVivillonQuest(PokemonType.Poison, 'Vivillon (Jungle)', ['Moor of Icirrus'], 'It has been spotted in a swamp.');
         createVivillonQuest(PokemonType.Dark, 'Vivillon (Monsoon)', ['Dark Cave'], 'It\'s hiding at a dark place.');
         createVivillonQuest(PokemonType.Steel, 'Vivillon (Tundra)', ['Pokéball Factory'], 'It flew into a factory.');
-        createVivillonQuest(PokemonType.Fire, 'Vivillon (Sun)', ['Mt. Chimney'], 'It seems to like hot places.');
+        createVivillonQuest(PokemonType.Fire, 'Vivillon (Sun)', ['Mt. Chimney Crater'], 'It seems to like hot places.');
         createVivillonQuest(PokemonType.Fighting, 'Vivillon (Archipelago)', ['Sprout Tower'], 'It\'s sitting on a swaying pillar.');
         createVivillonQuest(PokemonType.Ghost, 'Vivillon (Elegant)', ['Lost Hotel'], 'It\'s visiting an abandoned and spooky place.');
         createVivillonQuest(PokemonType.Fairy, 'Vivillon (Ocean)', ['Dreamyard'], 'It\'s flying around an overgrown place full of dreams.');


### PR DESCRIPTION
No need for a update method. Everything is saved based on dungeon index, and that does not change.
There where missing some renames from Mt Chimney to Mt Chimney Crater for it to work. This PR fixes that.