### PR TITLE
Roamers are now grouped by more than subregion

### DIFF
--- a/src/modules/routes/Routes.ts
+++ b/src/modules/routes/Routes.ts
@@ -1,4 +1,5 @@
 import * as GameConstants from '../GameConstants';
+import SubRegions from '../subRegion/SubRegions';
 import RegionRoute from './RegionRoute';
 
 export default class Routes {
@@ -22,6 +23,11 @@ export default class Routes {
 
     public static getRoutesByRegion(region: GameConstants.Region): RegionRoute[] {
         return this.regionRoutes.filter((routeData) => routeData.region === region);
+    }
+
+    public static getRoutesBySubRegionRoamerGroup(region: GameConstants.Region, subRegionGroup: number): RegionRoute[] {
+        return this.regionRoutes.filter((routeData) => routeData.region === region
+            && SubRegions.getSubRegionById(routeData.region, routeData.subRegion ?? 0).roamerSubRegionGroup === subRegionGroup);
     }
 
     public static getRegionByRoute(route: number): GameConstants.Region {

--- a/src/modules/subRegion/SubRegion.ts
+++ b/src/modules/subRegion/SubRegion.ts
@@ -8,6 +8,7 @@ export default class SubRegion {
         public requirement?: Requirement,
         public startTown?: string,
         public startRoute?: number,
+        public roamerSubRegionGroup = 0,
     ) {}
 
     public unlocked(): boolean {

--- a/src/modules/subRegion/SubRegions.ts
+++ b/src/modules/subRegion/SubRegions.ts
@@ -38,8 +38,8 @@ export default class SubRegions {
     }
 }
 
-SubRegions.addSubRegion(Region.kanto, new SubRegion('Kanto', undefined, 'Vermilion City'));
-SubRegions.addSubRegion(Region.kanto, new SubRegion('Sevii Islands 123', new GymBadgeRequirement(BadgeEnums.Volcano), 'One Island'));
+SubRegions.addSubRegion(Region.kanto, new SubRegion('Kanto', undefined, 'Vermilion City', undefined, 0));
+SubRegions.addSubRegion(Region.kanto, new SubRegion('Sevii Islands 123', new GymBadgeRequirement(BadgeEnums.Volcano), 'One Island', undefined, 1));
 
 export enum KantoSubRegions {
     Kanto = 0,
@@ -67,19 +67,19 @@ export enum AlolaSubRegions {
     // PoniIsland,
 }
 
-SubRegions.addSubRegion(Region.galar, new SubRegion('Galar', undefined, 'Postwick'));
+SubRegions.addSubRegion(Region.galar, new SubRegion('Galar', undefined, 'Postwick', undefined, 0));
 // For once Galar is split into 2 regions
-// SubRegions.addSubRegion(GameConstants.Region.galar, new SubRegion('Galar South', undefined, 'Postwick'));
-// SubRegions.addSubRegion(GameConstants.Region.galar, new SubRegion('Galar North', new RouteKillRequirement(10, GameConstants.Region.galar, 14), 'Hammerlocke'));
+// SubRegions.addSubRegion(GameConstants.Region.galar, new SubRegion('Galar South', undefined, 'Postwick', undefined, 0));
+// SubRegions.addSubRegion(GameConstants.Region.galar, new SubRegion('Galar North', new RouteKillRequirement(10, GameConstants.Region.galar, 14), 'Hammerlocke', undefined, 0));
 // Galar DLC islands
 SubRegions.addSubRegion(Region.galar, new SubRegion('Isle of Armor', new MultiRequirement([
     new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion),
     new NullRequirement(),
-])));
+]), undefined, undefined, 1));
 SubRegions.addSubRegion(Region.galar, new SubRegion('Crown Tundra', new MultiRequirement([
     new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion),
     new NullRequirement(),
-])));
+]), undefined, undefined, 2));
 
 export enum GalarSubRegions {
     Galar = 0,

--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -108,7 +108,7 @@ class Battle {
      */
     public static generateNewEnemy() {
         this.counter = 0;
-        this.enemyPokemon(PokemonFactory.generateWildPokemon(player.route(), player.region));
+        this.enemyPokemon(PokemonFactory.generateWildPokemon(player.route(), player.region, SubRegions.getSubRegionById(player.region, player.subRegion)));
         const enemyPokemon = this.enemyPokemon();
         GameHelper.incrementObservable(App.game.statistics.pokemonEncountered[enemyPokemon.id]);
         GameHelper.incrementObservable(App.game.statistics.totalPokemonEncountered);

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -218,11 +218,11 @@ class PokemonHelper {
 
     public static getPokemonRoamingRegions(pokemonName: PokemonNameType, maxRegion: GameConstants.Region = GameConstants.Region.none): Array<string> {
         const regions = [];
-        Object.entries(RoamingPokemonList.list).forEach(([region, pokemonArr]) => {
+        Object.entries(RoamingPokemonList.list).forEach(([region, regionArr]) => {
             if (maxRegion != GameConstants.Region.none && (+region) > maxRegion) {
                 return false;
             }
-            const pokemon = pokemonArr.find(r => r.pokemon.name == pokemonName);
+            const pokemon = regionArr.flat().find(r => r.pokemon.name == pokemonName);
             if (pokemon) {
                 const data = {
                     region: +region,

--- a/src/scripts/pokemons/RoamingPokemonList.ts
+++ b/src/scripts/pokemons/RoamingPokemonList.ts
@@ -4,31 +4,38 @@
 ///<reference path="../../declarations/requirements/OneFromManyRequirement.d.ts"/>
 
 class RoamingPokemonList {
-    public static list: Partial<Record<GameConstants.Region, Array<RoamingPokemon>>> = {};
-    public static increasedChanceRoute: Array<KnockoutObservable<RegionRoute>> = new Array(GameHelper.enumLength(GameConstants.Region)).fill(0).map((route, region) => ko.observable(null));
+    public static list: Partial<Record<GameConstants.Region, Array<Array<RoamingPokemon>>>> = {};
+    public static increasedChanceRoute: Array<Array<KnockoutObservable<RegionRoute>>> = [];
 
     constructor() { }
 
-    public static add(region: GameConstants.Region, roamer: RoamingPokemon): void {
+    public static add(region: GameConstants.Region, subRegionGroup: number, roamer: RoamingPokemon): void {
         if (!RoamingPokemonList.list[region]) {
             RoamingPokemonList.list[region] = [];
+            RoamingPokemonList.increasedChanceRoute[region] = [];
         }
-        RoamingPokemonList.list[region].push(roamer);
+        if (!RoamingPokemonList.list[region][subRegionGroup]) {
+            RoamingPokemonList.list[region][subRegionGroup] = [];
+            RoamingPokemonList.increasedChanceRoute[region][subRegionGroup] = ko.observable(undefined);
+        }
+        RoamingPokemonList.list[region][subRegionGroup].push(roamer);
     }
 
-    public static remove(region: GameConstants.Region, pokemonName: PokemonNameType): void {
-        const index = RoamingPokemonList.list[region].findIndex(r => r.pokemon.name == pokemonName);
+    public static remove(region: GameConstants.Region, subRegionGroup: number, pokemonName: PokemonNameType): void {
+        const index = RoamingPokemonList.list[region][subRegionGroup].findIndex(r => r.pokemon.name == pokemonName);
         if (index >= 0) {
-            RoamingPokemonList.list[region].splice(index, 1);
+            RoamingPokemonList.list[region][subRegionGroup].splice(index, 1);
         }
     }
 
-    public static getRegionalRoamers(region: GameConstants.Region): Array<RoamingPokemon> {
-        return RoamingPokemonList.list[region] ? RoamingPokemonList.list[region].filter(p => p.isRoaming()) : [];
+    public static getSubRegionalGroupRoamers(region: GameConstants.Region, subRegionGroup: number): Array<RoamingPokemon> {
+        return RoamingPokemonList.list[region] && RoamingPokemonList.list[region][subRegionGroup] ?
+            RoamingPokemonList.list[region][subRegionGroup].filter(p => p.isRoaming()) :
+            [];
     }
 
-    public static getIncreasedChanceRouteByRegion(region: GameConstants.Region): KnockoutObservable<RegionRoute> {
-        return this.increasedChanceRoute[region];
+    public static getIncreasedChanceRouteBySubRegionGroup(region: GameConstants.Region, subRegionGroup: number): KnockoutObservable<RegionRoute> {
+        return RoamingPokemonList.increasedChanceRoute[region]?.[subRegionGroup];
     }
 
     // How many hours between when the roaming Pokemon change routes for increased chances
@@ -38,81 +45,60 @@ class RoamingPokemonList {
         // Seed the random runmber generator
         SeededRand.seedWithDateHour(date, this.period);
 
-        this.increasedChanceRoute.forEach((route, region) => {
-            const routes = Routes.getRoutesByRegion(region);
-            // Select a route
-            const selectedRoute = SeededRand.fromArray(routes);
-            route(selectedRoute);
+        RoamingPokemonList.increasedChanceRoute.forEach((subRegionGroups, region) => {
+            subRegionGroups.forEach((route, subRegion) => {
+                const routes = Routes.getRoutesBySubRegionRoamerGroup(region, subRegion);
+                // Select a route
+                const selectedRoute = SeededRand.fromArray(routes);
+                route(selectedRoute);
+            });
         });
     }
 }
 
 // Kanto
-RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Mew', new SubregionRequirement(GameConstants.Region.kanto, KantoSubRegions.Kanto)));
+RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Mew'));
 
 // Johto
-RoamingPokemonList.add(GameConstants.Region.johto, new RoamingPokemon('Raikou', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))));
-RoamingPokemonList.add(GameConstants.Region.johto, new RoamingPokemon('Entei', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))));
-RoamingPokemonList.add(GameConstants.Region.johto, new RoamingPokemon('Suicune', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))));
+RoamingPokemonList.add(GameConstants.Region.johto, 0, new RoamingPokemon('Raikou', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))));
+RoamingPokemonList.add(GameConstants.Region.johto, 0, new RoamingPokemon('Entei', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))));
+RoamingPokemonList.add(GameConstants.Region.johto, 0, new RoamingPokemon('Suicune', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Burned Tower'))));
 
 // Hoenn
-RoamingPokemonList.add(GameConstants.Region.hoenn, new RoamingPokemon('Latios', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)));
-RoamingPokemonList.add(GameConstants.Region.hoenn, new RoamingPokemon('Latias', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)));
+RoamingPokemonList.add(GameConstants.Region.hoenn, 0, new RoamingPokemon('Latios', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)));
+RoamingPokemonList.add(GameConstants.Region.hoenn, 0, new RoamingPokemon('Latias', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)));
 // TODO: these need another way to be obtained
-RoamingPokemonList.add(GameConstants.Region.hoenn, new RoamingPokemon('Jirachi', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)));
+RoamingPokemonList.add(GameConstants.Region.hoenn, 0, new RoamingPokemon('Jirachi', new GymBadgeRequirement(BadgeEnums.Elite_HoennChampion)));
 
 // Sinnoh
-RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon('Manaphy'));
-RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon('Mesprit', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Distortion World'))));
-RoamingPokemonList.add(GameConstants.Region.sinnoh, new RoamingPokemon('Cresselia', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Fullmoon Island'))));
+RoamingPokemonList.add(GameConstants.Region.sinnoh, 0, new RoamingPokemon('Manaphy'));
+RoamingPokemonList.add(GameConstants.Region.sinnoh, 0, new RoamingPokemon('Mesprit', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Distortion World'))));
+RoamingPokemonList.add(GameConstants.Region.sinnoh, 0, new RoamingPokemon('Cresselia', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Fullmoon Island'))));
 
 // Unova
-RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon('Tornadus', new GymBadgeRequirement(BadgeEnums.Legend)));
-RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon('Thundurus', new GymBadgeRequirement(BadgeEnums.Legend)));
-RoamingPokemonList.add(GameConstants.Region.unova, new RoamingPokemon('Meloetta (aria)', new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)));
+RoamingPokemonList.add(GameConstants.Region.unova, 0, new RoamingPokemon('Tornadus', new GymBadgeRequirement(BadgeEnums.Legend)));
+RoamingPokemonList.add(GameConstants.Region.unova, 0, new RoamingPokemon('Thundurus', new GymBadgeRequirement(BadgeEnums.Legend)));
+RoamingPokemonList.add(GameConstants.Region.unova, 0, new RoamingPokemon('Meloetta (aria)', new GymBadgeRequirement(BadgeEnums.Elite_UnovaChampion)));
 
 // Kalos
-RoamingPokemonList.add(GameConstants.Region.kalos, new RoamingPokemon('Zapdos', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Sea Spirit\'s Den'))));
-RoamingPokemonList.add(GameConstants.Region.kalos, new RoamingPokemon('Moltres', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Sea Spirit\'s Den'))));
-RoamingPokemonList.add(GameConstants.Region.kalos, new RoamingPokemon('Articuno', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Sea Spirit\'s Den'))));
-RoamingPokemonList.add(GameConstants.Region.kalos, new RoamingPokemon('Hoopa', new GymBadgeRequirement(BadgeEnums.Elite_KalosChampion)));
+RoamingPokemonList.add(GameConstants.Region.kalos, 0, new RoamingPokemon('Zapdos', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Sea Spirit\'s Den'))));
+RoamingPokemonList.add(GameConstants.Region.kalos, 0, new RoamingPokemon('Moltres', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Sea Spirit\'s Den'))));
+RoamingPokemonList.add(GameConstants.Region.kalos, 0, new RoamingPokemon('Articuno', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Sea Spirit\'s Den'))));
+RoamingPokemonList.add(GameConstants.Region.kalos, 0, new RoamingPokemon('Hoopa', new GymBadgeRequirement(BadgeEnums.Elite_KalosChampion)));
 
 //Alola
-RoamingPokemonList.add(GameConstants.Region.alola, new RoamingPokemon('Magearna', new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)));
-RoamingPokemonList.add(GameConstants.Region.alola, new RoamingPokemon('Marshadow', new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)));
-RoamingPokemonList.add(GameConstants.Region.alola, new RoamingPokemon('Zeraora', new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)));
+RoamingPokemonList.add(GameConstants.Region.alola, 0, new RoamingPokemon('Magearna', new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)));
+RoamingPokemonList.add(GameConstants.Region.alola, 0, new RoamingPokemon('Marshadow', new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)));
+RoamingPokemonList.add(GameConstants.Region.alola, 0, new RoamingPokemon('Zeraora', new GymBadgeRequirement(BadgeEnums.Elite_AlolaChampion)));
 
 //Galar
-RoamingPokemonList.add(GameConstants.Region.galar, new RoamingPokemon('Galarian Articuno', new MultiRequirement([
-    new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Dyna Tree Hill')),
-    new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.Galar),
-    // TODO: uncomment this once Galar split into 2
-    // new OneFromManyRequirement([
-    //     new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.GalarNorth),
-    //     new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.GalarSouth),
-    // ]),
-])));
+RoamingPokemonList.add(GameConstants.Region.galar, 0, new RoamingPokemon('Galarian Articuno', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Dyna Tree Hill'))));
 
 //Galar - Isle of Armor
-RoamingPokemonList.add(GameConstants.Region.galar, new RoamingPokemon('Zarude', new MultiRequirement([
-    new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion),
-    new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.IsleOfArmor),
-])));
-RoamingPokemonList.add(GameConstants.Region.galar, new RoamingPokemon('Galarian Moltres', new MultiRequirement([
-    new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Dyna Tree Hill')),
-    new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.IsleOfArmor),
-])));
+RoamingPokemonList.add(GameConstants.Region.galar, 1, new RoamingPokemon('Zarude', new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion)));
+RoamingPokemonList.add(GameConstants.Region.galar, 1, new RoamingPokemon('Galarian Moltres', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Dyna Tree Hill'))));
 
 //Galar - Crown Tundra
-RoamingPokemonList.add(GameConstants.Region.galar, new RoamingPokemon('Spectrier', new MultiRequirement([
-    new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion),
-    new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.CrownTundra),
-])));
-RoamingPokemonList.add(GameConstants.Region.galar, new RoamingPokemon('Glastrier', new MultiRequirement([
-    new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion),
-    new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.CrownTundra),
-])));
-RoamingPokemonList.add(GameConstants.Region.galar, new RoamingPokemon('Galarian Zapdos', new MultiRequirement([
-    new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Dyna Tree Hill')),
-    new SubregionRequirement(GameConstants.Region.galar, GalarSubRegions.CrownTundra),
-])));
+RoamingPokemonList.add(GameConstants.Region.galar, 2, new RoamingPokemon('Spectrier', new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion)));
+RoamingPokemonList.add(GameConstants.Region.galar, 2, new RoamingPokemon('Glastrier', new GymBadgeRequirement(BadgeEnums.Elite_GalarChampion)));
+RoamingPokemonList.add(GameConstants.Region.galar, 2, new RoamingPokemon('Galarian Zapdos', new ClearDungeonRequirement(1, GameConstants.getDungeonIndex('Dyna Tree Hill'))));

--- a/src/scripts/specialEvents/SpecialEvents.ts
+++ b/src/scripts/specialEvents/SpecialEvents.ts
@@ -45,11 +45,11 @@ class SpecialEvents implements Feature {
 SpecialEvents.newEvent('Lunar New Year', 'Encounter Fancy Pattern Vivillon for a limited time roaming Kalos.',
     // Start
     new Date(new Date().getFullYear(), 0, 24, 1), () => {
-        RoamingPokemonList.add(GameConstants.Region.kalos, new RoamingPokemon('Vivillon (Fancy)'));
+        RoamingPokemonList.add(GameConstants.Region.kalos, 0, new RoamingPokemon('Vivillon (Fancy)'));
     },
     // End
     new Date(new Date().getFullYear(), 1, 7, 23), () => {
-        RoamingPokemonList.remove(GameConstants.Region.kalos, 'Vivillon (Fancy)');
+        RoamingPokemonList.remove(GameConstants.Region.kalos, 0, 'Vivillon (Fancy)');
     }
 );
 // Easter
@@ -70,11 +70,11 @@ SpecialEvents.newEvent('Easter', 'Encounter Surprise Togepi for a limited time w
 SpecialEvents.newEvent('Flying Pikachu', 'Encounter Flying Pikachu for a limited time roaming Kanto.',
     // Start
     new Date(new Date().getFullYear(), 6, 6, 1), () => {
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Flying Pikachu'));
+        RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Flying Pikachu'));
     },
     // End
     new Date(new Date().getFullYear(), 6, 12, 23), () => {
-        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Flying Pikachu');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 0, 'Flying Pikachu');
     }
 );
 // Pokemon the first movie release date
@@ -82,14 +82,16 @@ SpecialEvents.newEvent('Mewtwo strikes back!', 'Encounter Armored Mewtwo for a l
     // Start
     new Date(new Date().getFullYear(), 6, 18, 1), () => {
         dungeonList['Cerulean Cave'].bossList.push(new DungeonBossPokemon('Armored Mewtwo', 1000000, 80));
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Bulbasaur (clone)'));
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Charmander (clone)'));
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Squirtle (clone)'));
+        RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Bulbasaur (clone)'));
+        RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Charmander (clone)'));
+        RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Squirtle (clone)'));
     },
     // End
     new Date(new Date().getFullYear(), 6, 24, 23), () => {
         dungeonList['Cerulean Cave'].bossList = dungeonList['Cerulean Cave'].bossList.filter(boss => boss.name != 'Armored Mewtwo');
-        RoamingPokemonList.list[GameConstants.Region.kanto] = RoamingPokemonList.list[GameConstants.Region.kanto].filter(r => !['Bulbasaur (clone)', 'Charmander (clone)', 'Squirtle (clone)'].includes(r.pokemon.name));
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 0, 'Bulbasaur (clone)');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 0, 'Charmander (clone)');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 0, 'Squirtle (clone)');
     }
 );
 // Halloween
@@ -122,13 +124,13 @@ SpecialEvents.newEvent('Halloween!', 'Encounter Spooky Pokémon for a limited ti
 SpecialEvents.newEvent('Let\'s GO!', 'Encounter special Eevee and Pikachu roaming in the Kanto region.',
     // Start
     new Date(new Date().getFullYear(), 10, 16, 1), () => {
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Let\'s Go Pikachu'));
-        RoamingPokemonList.add(GameConstants.Region.kanto, new RoamingPokemon('Let\'s Go Eevee'));
+        RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Let\'s Go Pikachu'));
+        RoamingPokemonList.add(GameConstants.Region.kanto, 0, new RoamingPokemon('Let\'s Go Eevee'));
     },
     // End
     new Date(new Date().getFullYear(), 10, 23, 23), () => {
-        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Let\'s Go Pikachu');
-        RoamingPokemonList.remove(GameConstants.Region.kanto, 'Let\'s Go Eevee');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 0, 'Let\'s Go Pikachu');
+        RoamingPokemonList.remove(GameConstants.Region.kanto, 0, 'Let\'s Go Eevee');
     }
 );
 // Christmas
@@ -137,7 +139,7 @@ SpecialEvents.newEvent('Merry Christmas!', 'Encounter Santa Snorlax roaming the 
     new Date(new Date().getFullYear(), 11, 24, 1), () => {
         // Add to every region excluding None
         GameHelper.enumNumbers(GameConstants.Region).filter(i => i != GameConstants.Region.none).forEach(region => {
-            RoamingPokemonList.add(region, new RoamingPokemon('Santa Snorlax'));
+            RoamingPokemonList.add(region, 0, new RoamingPokemon('Santa Snorlax'));
         });
         dungeonList['Ilex Forest'].bossList.push(new DungeonBossPokemon('Grinch Celebi', 1600000, 100, {requirement: new GymBadgeRequirement(BadgeEnums.Elite_JohtoChampion)}));
     },
@@ -145,7 +147,7 @@ SpecialEvents.newEvent('Merry Christmas!', 'Encounter Santa Snorlax roaming the 
     new Date(new Date().getFullYear(), 11, 30, 23), () => {
         // Remove from every region excluding None
         GameHelper.enumNumbers(GameConstants.Region).filter(i => i != GameConstants.Region.none).forEach(region => {
-            RoamingPokemonList.remove(region, 'Santa Snorlax');
+            RoamingPokemonList.remove(region, 0, 'Santa Snorlax');
         });
         dungeonList['Ilex Forest'].bossList = dungeonList['Ilex Forest'].bossList.filter(boss => boss.name != 'Grinch Celebi');
     }

--- a/src/scripts/towns/RoamerNPC.ts
+++ b/src/scripts/towns/RoamerNPC.ts
@@ -3,14 +3,15 @@ class RoamerNPC extends NPC {
     constructor(
         public name: string,
         public dialog: string[],
-        public region: GameConstants.Region
+        public region: GameConstants.Region,
+        public subRegionRoamerGroup: number
     ) {
         super(name, dialog);
     }
 
     get dialogHTML(): string {
-        const route = RoamingPokemonList.getIncreasedChanceRouteByRegion(this.region);
-        const roamers = RoamingPokemonList.getRegionalRoamers(this.region);
+        const route = RoamingPokemonList.getIncreasedChanceRouteBySubRegionGroup(this.region, this.subRegionRoamerGroup);
+        const roamers = RoamingPokemonList.getSubRegionalGroupRoamers(this.region, this.subRegionRoamerGroup);
 
         // If no roaming Pokemon yet
         if (!roamers.length) {

--- a/src/scripts/towns/TownList.ts
+++ b/src/scripts/towns/TownList.ts
@@ -157,7 +157,7 @@ const SaffronBattleItemRival = new NPC('Battle Item Master', [
 
 const FuchsiaKantoRoamerNPC = new RoamerNPC('Youngster Wendy', [
     'There\'s been some recent sightings of roaming Pokémon on {ROUTE_NAME}!',
-], GameConstants.Region.kanto);
+], GameConstants.Region.kanto, 0);
 
 const CinnabarIslandResearcher = new NPC('Researcher', [
     'They were trying to clone an ancient Pokémon in the mansion, I wonder if they succeeded.',
@@ -530,7 +530,7 @@ const MahoganySouvenirShopAttendant = new NPC('Souvenir Shop Attendant', [
 
 const BlackthornJohtoRoamerNPC = new RoamerNPC('Pokéfan Trevor', [
     'On the news they are getting more reports of roaming Pokémon appearing on {ROUTE_NAME}!',
-], GameConstants.Region.johto);
+], GameConstants.Region.johto, 0);
 
 
 //Johto Towns
@@ -816,7 +816,7 @@ const OldaleTrackingScientist = new NPC('Tracking Scientist', [
 
 const SlateportHoennRoamerNPC = new RoamerNPC('Reporter Gabby', [
     'Our sources indicate that roaming Pokémon are gathering on {ROUTE_NAME}!',
-], GameConstants.Region.hoenn);
+], GameConstants.Region.hoenn, 0);
 
 const FallarborProfessorCozmo = new NPC('Prof. Cozmo', [
     'Oh! Welcome, welcome. Do you by any chance have any Meteorites? No? Ah well, I’m studying the Pokémon Deoxys and I’ve heard that a Meteorite can cause it to change forms!',
@@ -1255,7 +1255,7 @@ const SunyshoreRibbonerJulia = new NPC('Ribboner Julia', [
 
 const SurvivalAreaSinnohRoamerNPC = new RoamerNPC('Hiker Kevin', [
     'I spotted a bunch of roaming Pokémon on {ROUTE_NAME}!',
-], GameConstants.Region.sinnoh);
+], GameConstants.Region.sinnoh, 0);
 
 //Sinnoh Towns
 TownList['Twinleaf Town'] = new Town(
@@ -1689,7 +1689,7 @@ const IcirrusFanClubChairman = new NPC('Fan Club Chairman', [
 
 const UnovaRoamerNPC = new RoamerNPC('Professor Juniper\'s Aide', [
     'Our research indicates a higher concentration of roaming Pokémon on {ROUTE_NAME}!',
-], GameConstants.Region.unova);
+], GameConstants.Region.unova, 0);
 
 //Unova Towns
 TownList['Aspertia City'] = new Town(
@@ -2142,7 +2142,7 @@ const LaverreFurisodeGirlKatherine = new NPC('Furisode Girl Katherine', [
 
 const AnistarKalosRoamerNPC = new RoamerNPC('Hex Maniac Melanie', [
     'The spirits tell me roaming Pokémon have been spotted on {ROUTE_NAME}!',
-], GameConstants.Region.kalos);
+], GameConstants.Region.kalos, 0);
 
 const KiloudeConfusedHiker = new NPC('Confused Hiker', [
     'Whoa! What the- Where am I? How did I get here? Last thing I can remember I was in Reflection Cave when this little Pokémon with hoops threw something at me… Oh you’ve beaten the Pokémon League? Maybe you can find it roaming around the region so you can tame that little prankster. Now how am I gonna get home…',
@@ -2495,7 +2495,7 @@ const SeafolkCaptain = new NPC('Captain Mina', [
 ]);
 const AetherParadiseAlolaRoamerNPC = new RoamerNPC('Assistant Branch Chief Wicke', [
     'Some very rare Pokémon have been sighted on {ROUTE_NAME}. I hope we can learn more about them.',
-], GameConstants.Region.alola);
+], GameConstants.Region.alola, 0);
 
 //Alola Towns
 


### PR DESCRIPTION
Each subregion now has a "roamerSubRegionGroup" parameter, each roamer now has a "subRegionGroup" parameter and each RoamerNpc has a "subRegionRoamerGroup" parameter.
This PR splits up roamers into thoese groups. Each group has one increased chance route, and the npc will only show their roamers.
The only thing, which was hard to test, is if roamers still stay in their region. But i think they do.